### PR TITLE
Updated readme with Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Automated Install 
+# Deprecation
+
+This repository has been deprecated. Please refer to <https://github.com/pi-hole/docker-pi-hole> for your Docker Pi-Hole needs.
+
+# Automated Install
 ##### Designed For Raspberry Pi A+, B, B+, 2, Zero, and 3B (with an Ethernet/Wi-Fi adapter) (Works on most Debian distributions!)
 
 1. Install Raspbian 


### PR DESCRIPTION
Changes proposed in this pull request:

- Notify people up front that this repository is no longer the place to go for Docker pi-hole needs.

@pi-hole/gravity
